### PR TITLE
Ensure callback is not called in the same stack

### DIFF
--- a/image-to-data-uri.js
+++ b/image-to-data-uri.js
@@ -24,7 +24,7 @@ module.exports = function (url, cb) {
 
     // canvas is not supported
     if (!canvas.getContext) {
-        cb(new Error('CanvasIsNotSupported'));
+        setTimeout(cb, 0, new Error('CanvasIsNotSupported'));
     } else {
         img.src = url;
     }


### PR DESCRIPTION
Ensures that the callback will not be called synchronously.

(See isaacs post on [designing apis for asynchrony](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).)
