### PR TITLE
node-style err callback like the readme says

### DIFF
--- a/image-to-data-uri.js
+++ b/image-to-data-uri.js
@@ -15,7 +15,7 @@ module.exports = function (url, cb) {
         ctx.drawImage(img, 0, 0);
 
         // Get the data-URI formatted image
-        cb(canvas.toDataURL('image/png'));
+        cb(null, canvas.toDataURL('image/png'));
     };
 
     img.ononerror = function () {


### PR DESCRIPTION
The readme says `cb(err, uri)` but it does `cb(err)` and `cb(uri)`
