### PR TITLE
set `crossOrigin` attribute on images

### DIFF
--- a/image-to-data-uri.js
+++ b/image-to-data-uri.js
@@ -26,6 +26,7 @@ module.exports = function (url, cb) {
     if (!canvas.getContext) {
         setTimeout(cb, 0, new Error('CanvasIsNotSupported'));
     } else {
+        img.setAttribute('crossOrigin', 'anonymous')
         img.src = url;
     }
 };


### PR DESCRIPTION
This will allow images to be downloaded from many more sites, unless they specifically opt out of CORS support. Learned from this Stack Overflow posting: http://stackoverflow.com/a/27260385/154765

cc @HenrikJoreteg 
